### PR TITLE
[AIRFLOW-contrib-aws_dynamodb_hook] Fix typo

### DIFF
--- a/airflow/contrib/hooks/aws_dynamodb_hook.py
+++ b/airflow/contrib/hooks/aws_dynamodb_hook.py
@@ -19,7 +19,7 @@
 
 
 """
-This module contains AWS Athena hook
+This module contains the AWS DynamoDB hook
 """
 from airflow.contrib.hooks.aws_hook import AwsHook
 from airflow.exceptions import AirflowException
@@ -54,7 +54,7 @@ class AwsDynamoDBHook(AwsHook):
 
     def write_batch_data(self, items):
         """
-        Write batch items to dynamodb table with provisioned throughout capacity.
+        Write batch items to DynamoDB table with provisioned throughout capacity.
         """
 
         dynamodb_conn = self.get_conn()


### PR DESCRIPTION
### Description

- Fix typo correcting that the hook is for DynamoDB not Athena. Well, it is my second PR overall and I have the feeling I produce more work than benefit with changes like this? Feedback appreciated :cactus: 